### PR TITLE
add an extra include directory to the mb_depends_on_mbcoreutils, this…

### DIFF
--- a/mb_install.py
+++ b/mb_install.py
@@ -417,6 +417,8 @@ def define_cmake_dependency(env, libname):
 def mb_depends_on_mb_core_utils(env):
     define_library_dependency(env, 'MBCoreUtils', '#/../MBCoreUtils',
                               header_only=True)
+    mb_add_include_paths(env, os.path.join(env['MB_INCLUDE_DIR'],
+                                               "bwcoreutils"))
 
 def mb_depends_on_mbqtutils(env):
     define_cmake_dependency(env, 'mbqtutils')


### PR DESCRIPTION
… is used by birdwing acceleration to find the machine_cpp files

BST-224
http://jira.makerbot.net/browse/BST-224
