### PR TITLE
Don't install .git directory

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -7,11 +7,11 @@ env = Environment(
 # do not install any file that matches
 # any of these patterns
 excludes = [
-    '(^.*\.git(/.*)?$)',
-    '(^.*debian(/.*)?$)',
-    '(^.*obj/(.*)$)',
-    '(^.*\.pyc$)',
-    '(^.*\.gitignore$)']
+    r'(^.*\.git(/|\\)(.*)$)',
+    r'(^.*debian(/|\\)(.*)$)',
+    r'(^.*obj/(.*)$)',
+    r'(^.*\.pyc$)',
+    r'(^.*\.gitignore$)']
 exclude_pat = '|'.join(excludes)
 exclude_re = re.compile(exclude_pat)
 


### PR DESCRIPTION
The regexes were assuming posix paths,
I've updated them and they seem to work on windows. untested on mac.

http://maven.soft.makerbot.net/artifactory/Makerbot-local/mw-scons-tools/win-dont-install-.git/Windows_64/
